### PR TITLE
update package to release build + debian artifacts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,3 +77,13 @@ assets = [
 ]
 post_install_script = "rpm/systemd-start.sh"
 pre_uninstall_script = "rpm/systemd-stop.sh"
+
+[package.metadata.deb]
+assets = [
+    { source = "target/release/rezolus", dest = "/usr/bin/", mode = "755" },
+    { source = "config/agent.toml", dest = "/etc/rezolus/", mode = "644" },
+    { source = "debian/90-rezolus-flight-recorder.preset", dest = "usr/lib/systemd/system-preset/", mode = "644" },
+    { source = "debian/rezolus-flight-recorder.service", dest = "/usr/lib/systemd/system/", mode = "644" },
+]
+maintainer-scripts = "debian/"
+systemd-units = { enable = true }

--- a/fastly-build/Dockerfile
+++ b/fastly-build/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y \
   && apt-get -qy clean \
   && rm -rf /var/lib/apt/lists/*
 
-RUN cargo deb --deb-version $PKG_VERSION --output $DESTDIR
+RUN cargo deb --deb-version $PKG_VERSION --output $DESTDIR --profile release
 
 FROM gcr.io/distroless/cc-debian11
 WORKDIR /


### PR DESCRIPTION
package debian files `cargo deb` is currently skipping because they are handle in shell scripts in the upstream version.